### PR TITLE
Fix browser command-line arguments type error

### DIFF
--- a/browser.lisp
+++ b/browser.lisp
@@ -40,7 +40,7 @@
     (format stream arg-format head (if (consp tail) (first tail) tail))))
 
 (defun encode-application-options (options arg-format)
-  "Turns OPTIONS, an alist, into a command line argument list according to ARG-FORMAT"
+  "Turns OPTIONS, an alist, into a command line argument string according to ARG-FORMAT"
   ;; Chrome arg-format: "--~A=~A"
   ;; Firefox: "-~A ~A"
   (declare (special arg-format))

--- a/plot.lisp
+++ b/plot.lisp
@@ -6,11 +6,12 @@
   "Open plot specification FILESPEC"
   (let ((plot-file (namestring (truename filespec))))
     #+windows (setf plot-file (concatenate 'string "file:///" plot-file))
-    (uiop:launch-program `(,(alexandria:assoc-value plot:*browser-commands* browser)
-			   ,@(case browser
-			     (:chrome (if (assoc "app" browser-options :test 'string=)
-					  (setf (cdr (assoc "app" browser-options :test 'string=)) plot-file))
-			      (encode-chrome-options browser-options))
-			     (:default plot-file)))
+    (uiop:launch-program (format nil "~A ~A"
+                                 (alexandria:assoc-value plot:*browser-commands* browser)
+			         (case browser
+			           (:chrome (if (assoc "app" browser-options :test 'string=)
+					        (setf (cdr (assoc "app" browser-options :test 'string=)) plot-file))
+			            (encode-chrome-options browser-options))
+			           (:default plot-file)))
 			 :ignore-error-status t)))
 


### PR DESCRIPTION
This is a partial fix to make `PLOT-FROM-FILE` work on my Linux/NixOS machine. 

On branch `master` branch I get a type error when the string return value of `ENCODE-APPLICATION-OPTIONS` is spliced as if it were a list. This branch fixes that problem.

The behavior on this branch is now correct for me when `PLOT:*DEFAULT-BROWSER-COMMAND*` is set to `:DEFAULT` i.e. it uses `xdg-open` to load the plot in my default browser, Chrome.

The default setting of `:CHROME` does not work for me because my NixOS machine doesn't have an executable called `chrome` and the executable that I do have, `google-chrome-stable`, has the wrong behavior i.e. opens a new instances of Chrome and doesn't show the plot.

So this change seems like one improvement but more might be needed.