### PR TITLE
Bugfix to browser plot wrapper and support for passing column symbol names to histogram plot

### DIFF
--- a/plot.lisp
+++ b/plot.lisp
@@ -6,11 +6,12 @@
   "Open plot specification FILESPEC"
   (let ((plot-file (namestring (truename filespec))))
     #+windows (setf plot-file (concatenate 'string "file:///" plot-file))
-    (uiop:launch-program `(,(alexandria:assoc-value plot:*browser-commands* browser)
-			   ,(case browser
-			     (:chrome (if (assoc "app" browser-options :test 'string=)
-					  (setf (cdr (assoc "app" browser-options :test 'string=)) plot-file))
-			      (encode-chrome-options browser-options))
-			     (:default plot-file)))
+    #+(or macos darwin linux) (setf plot-file (concatenate 'string "file://" plot-file))
+    (uiop:launch-program  (append (list (alexandria:assoc-value plot:*browser-commands* browser))
+				  (cl-ppcre:split "\\s+" (case browser
+							   (:chrome (if (assoc "app" browser-options :test 'string=)
+									(setf (cdr (assoc "app" browser-options :test 'string=)) plot-file))
+							    (encode-chrome-options browser-options))
+							   (:default plot-file))))
 			 :ignore-error-status t)))
 

--- a/src/vglt/spec.lisp
+++ b/src/vglt/spec.lisp
@@ -73,7 +73,8 @@
 ;;(defun histogram (data &key (column nil) (title nil) (description nil))
 (defun histogram (data column &key (title nil) (description nil))
   "Return a Vega-Lite JSON specification for a histogram plot"
-  (assert (or (and (typep data 'df:data-frame) column)
+  (assert (or (and (typep data 'df:data-frame) (or (typep column 'symbol)
+						   (typep column 'string)))
 	      (typep data 'sequence))
 	  ()
 	  "If using a DATA-FRAME, a column must be given")
@@ -86,7 +87,10 @@
       (t (setf spec (acons "data" data spec))))
     (setf spec (acons "mark" "bar" spec))
     (etypecase data
-      (df:data-frame (setf spec (acons "encoding" `(("x" ("field" . ,column) ("bin" . t))
+      (df:data-frame (setf spec (acons "encoding" `(("x" ("field" . ,(if (typep column 'string)
+									 (string-upcase column)
+									 (symbol-name column)))
+							 ("bin" . t))
 						    ("y" ("aggregate" . "count")))
 				       spec)))
       (sequence (setf spec (acons "encoding" `(("x" ("field" . "X") ("bin" . t))


### PR DESCRIPTION
It took a while to figure out how to make this all work.