### PR TITLE
Implement split-stems

### DIFF
--- a/src/text/stem-and-leaf.lisp
+++ b/src/text/stem-and-leaf.lisp
@@ -24,14 +24,14 @@
                      (default is 1). Currently not implemented
        SPLIT-STEMS - if T the stems will be split. Currently not implemented."
   (declare (ignore leaf-size))		; we'll use it later
-  (declare (ignore split-stems))	; Not implemented. See github issue #2
+
   (check-type x vector)
-  (let* ((all-stems  (efloor (e/ x stem-size)))
+  (let* ((all-stems  (efloor (e/ x (if split-stems (/ stem-size 2) stem-size))))
 	 (all-leaves (emod x stem-size))
 	 (stem-fmt (format nil "~~~AD |" (length (format nil "~A" (sequence-maximum all-stems)))))
 	 (leaf-strings-vector (leaf-strings all-stems all-leaves)))
     (loop for s from (sequence-minimum all-stems) to (sequence-maximum all-stems)
-	  do (progn (format t stem-fmt s)
+	  do (progn (format t stem-fmt (if split-stems (floor (/ s 2)) s))
 		    (format t "~A~%" (gethash s leaf-strings-vector))))))
 
 (defun back-to-back-stem-and-leaf (x y &key (stem-size 10) (leaf-size 1) split-stems)


### PR DESCRIPTION
This pull request implements split-stems.

If split-stems is true, then instead instead of use mod 10 to calculate the stems, it uses mod 5. 
To calculate the base stem, it divides the stem by 2. For example with a vector  #(10 15 16 18)  by using mod 5 the stems become 2 3 3 3. When printing the  stems it divides by 2 and gets the floor so both 2 and 3 are printed as 1. 

Closes #2