### PR TITLE
Add lisp-stat dependency to system plot/vega

### DIFF
--- a/plot.asd
+++ b/plot.asd
@@ -44,6 +44,7 @@
   :author      "Steve Nunez <steve@symbolics.tech>"
   :licence     :MS-PL
   :depends-on ("plot"
+	       "lisp-stat"
 	       "lass"
 	       "cl-who"
 	       "quri"


### PR DESCRIPTION
plot/vega depends on the lisp-stat system.